### PR TITLE
Add open-with-cmd and bookmarks plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # [Yazi](https://yazi-rs.github.io/) plugins, packaged for Nix
-
 This is a collection of nix packages containing plugins for the Yazi TUI file manager.
 
 ## Usage
-
 In your `flake.nix`, add an input like so:
-
 ```nix
 {
   inputs.nix-yazi-plugins = {
@@ -22,11 +19,9 @@ There's also an overlay which will give you the packages under `pkgs.yaziPlugins
 The plugin packages provided by this flake can be used with the home-manager module for Yazi, see [`programs.yazi.plugins`](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.yazi.plugins).
 
 ### Home Manager Integration
-
 Easily enable plugins, a sensible default is already preconfigured.
 The init.lua, your keymaps, dependencies, plugins directory, ... are automatically managed for you
 example usage inside home-manager:
-
 ```nix
   imports = [
     (inputs.nix-yazi-plugins.legacyPackages.x86_64-linux.homeManagerModules.default)
@@ -54,35 +49,31 @@ example usage inside home-manager:
 ```
 
 ## Branches & Compatibility
-
 I try to support the latest release and the latest git of Yazi.
 If you run the unstable version, use the `main` branch.
 If you run the release version, use the corresponding branch, for example `yazi-v0.2.5`. Note that I won't delete unsupported release branches, so that your configs will still build in the future.
 
 ## Plugin list
 
-| Attribute name       | Short Description                                                                                                             | Upstream repo                                                                |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --- |
-| `bookmarks`          | A Yazi plugin that adds the basic functionality of vi-like marks                                                              | https://github.com/dedukun/bookmarks.yazi                                    |     |
-| `bypass`             | Skip directories with only a single sub-directory                                                                             | https://github.com/Rolv-Apneseth/bypass.yazi                                 |
-| `chmod`              | Execute chmod on the selected files to change their mode                                                                      | https://github.com/yazi-rs/plugins/tree/main/chmod.yazi                      |
-| `copy-file-contents` | Copy the contents of a file to clipboard directly from Yazi                                                                   | https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi |
-| `exifaudio`          | Preview audio files metadata on yazi                                                                                          | https://github.com/Sonico98/exifaudio.yazi                                   |
-| `full-border`        | Add a full border to Yazi to make it look fancier                                                                             | https://github.com/yazi-rs/plugins/tree/main/full-border.yazi                |
-| `glow`               | Plugin for Yazi to preview markdown files with glow                                                                           | https://github.com/Reledia/glow.yazi                                         |
-| `hide-preview`       | Switch the preview pane between hidden and shown                                                                              | https://github.com/yazi-rs/plugins/tree/main/hide-preview.yazi               |
-| `jump-to-char`       | Vim-like f<char>, jump to the next file whose name starts with <char>                                                         | https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi               |
-| `max-preview`        | Maximize or restore the preview pane                                                                                          | https://github.com/yazi-rs/plugins/tree/main/max-preview.yazi                |
-| `open-with-cmd`      | This is a Yazi plugin for opening files with a prompted command.                                                              | https://github.com/Ape/open-with-cmd.yazi                                    |
-| `ouch`               | A Yazi plugin to preview archives                                                                                             | https://github.com/ndtoan96/ouch.yazi                                        |
-| `relative-motions`   | basic vim motions like 3k, 12j, 10gg                                                                                          | https://github.com/dedukun/relative-motions.yazi                             |
-| `rich-preview`       | Rich preview plugin for yazi file manager                                                                                     | https://github.com/AnirudhG07/rich-preview.yazi                              |
-| `smart-filter`       | A Yazi plugin that makes filters smarter: continuous filtering, automatically enter unique directory, open file on submitting | https://github.com/yazi-rs/plugins/tree/main/smart-filter.yazi               |
-| `starship`           | Show starship prompt in header                                                                                                | https://github.com/Rolv-Apneseth/starship.yazi                               |
-| `system-clipboard`   | Cross platform implementation of a simple system clipboard for yazi file manager                                              | https://github.com/orhnk/system-clipboard.yazi                               |
+| Attribute name | Short Description | Upstream repo |
+| --- | --- | --- |
+| `bypass` | Skip directories with only a single sub-directory | https://github.com/Rolv-Apneseth/bypass.yazi |
+| `chmod` | Execute chmod on the selected files to change their mode | https://github.com/yazi-rs/plugins/tree/main/chmod.yazi |
+| `copy-file-contents` | Copy the contents of a file to clipboard directly from Yazi | https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi |
+| `exifaudio` | Preview audio files metadata on yazi | https://github.com/Sonico98/exifaudio.yazi |
+| `full-border` | Add a full border to Yazi to make it look fancier | https://github.com/yazi-rs/plugins/tree/main/full-border.yazi|
+| `glow` | Plugin for Yazi to preview markdown files with glow | https://github.com/Reledia/glow.yazi |
+| `hide-preview` | Switch the preview pane between hidden and shown | https://github.com/yazi-rs/plugins/tree/main/hide-preview.yazi |
+| `jump-to-char` | Vim-like f<char>, jump to the next file whose name starts with <char> | https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi |
+| `max-preview` | Maximize or restore the preview pane | https://github.com/yazi-rs/plugins/tree/main/max-preview.yazi |
+| `ouch` | A Yazi plugin to preview archives | https://github.com/ndtoan96/ouch.yazi |
+| `relative-motions` | basic vim motions like 3k, 12j, 10gg | https://github.com/dedukun/relative-motions.yazi |
+| `rich-preview` | Rich preview plugin for yazi file manager | https://github.com/AnirudhG07/rich-preview.yazi |
+| `smart-filter` | A Yazi plugin that makes filters smarter: continuous filtering, automatically enter unique directory, open file on submitting | https://github.com/yazi-rs/plugins/tree/main/smart-filter.yazi |
+| `starship` | Show starship prompt in header | https://github.com/Rolv-Apneseth/starship.yazi |
+| `system-clipboard` | Cross platform implementation of a simple system clipboard for yazi file manager | https://github.com/orhnk/system-clipboard.yazi |
 
 ## Contributing
-
 To request a new plugin or an update to an existing one, you can open an issue.
 Contributions are also welcome! Feel free to send PRs.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # [Yazi](https://yazi-rs.github.io/) plugins, packaged for Nix
+
 This is a collection of nix packages containing plugins for the Yazi TUI file manager.
 
 ## Usage
+
 In your `flake.nix`, add an input like so:
+
 ```nix
 {
   inputs.nix-yazi-plugins = {
@@ -19,9 +22,11 @@ There's also an overlay which will give you the packages under `pkgs.yaziPlugins
 The plugin packages provided by this flake can be used with the home-manager module for Yazi, see [`programs.yazi.plugins`](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.yazi.plugins).
 
 ### Home Manager Integration
+
 Easily enable plugins, a sensible default is already preconfigured.
 The init.lua, your keymaps, dependencies, plugins directory, ... are automatically managed for you
 example usage inside home-manager:
+
 ```nix
   imports = [
     (inputs.nix-yazi-plugins.legacyPackages.x86_64-linux.homeManagerModules.default)
@@ -49,31 +54,35 @@ example usage inside home-manager:
 ```
 
 ## Branches & Compatibility
+
 I try to support the latest release and the latest git of Yazi.
 If you run the unstable version, use the `main` branch.
 If you run the release version, use the corresponding branch, for example `yazi-v0.2.5`. Note that I won't delete unsupported release branches, so that your configs will still build in the future.
 
 ## Plugin list
 
-| Attribute name | Short Description | Upstream repo |
-| --- | --- | --- |
-| `bypass` | Skip directories with only a single sub-directory | https://github.com/Rolv-Apneseth/bypass.yazi |
-| `chmod` | Execute chmod on the selected files to change their mode | https://github.com/yazi-rs/plugins/tree/main/chmod.yazi |
-| `copy-file-contents` | Copy the contents of a file to clipboard directly from Yazi | https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi |
-| `exifaudio` | Preview audio files metadata on yazi | https://github.com/Sonico98/exifaudio.yazi |
-| `full-border` | Add a full border to Yazi to make it look fancier | https://github.com/yazi-rs/plugins/tree/main/full-border.yazi|
-| `glow` | Plugin for Yazi to preview markdown files with glow | https://github.com/Reledia/glow.yazi |
-| `hide-preview` | Switch the preview pane between hidden and shown | https://github.com/yazi-rs/plugins/tree/main/hide-preview.yazi |
-| `jump-to-char` | Vim-like f<char>, jump to the next file whose name starts with <char> | https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi |
-| `max-preview` | Maximize or restore the preview pane | https://github.com/yazi-rs/plugins/tree/main/max-preview.yazi |
-| `ouch` | A Yazi plugin to preview archives | https://github.com/ndtoan96/ouch.yazi |
-| `relative-motions` | basic vim motions like 3k, 12j, 10gg | https://github.com/dedukun/relative-motions.yazi |
-| `rich-preview` | Rich preview plugin for yazi file manager | https://github.com/AnirudhG07/rich-preview.yazi |
-| `smart-filter` | A Yazi plugin that makes filters smarter: continuous filtering, automatically enter unique directory, open file on submitting | https://github.com/yazi-rs/plugins/tree/main/smart-filter.yazi |
-| `starship` | Show starship prompt in header | https://github.com/Rolv-Apneseth/starship.yazi |
-| `system-clipboard` | Cross platform implementation of a simple system clipboard for yazi file manager | https://github.com/orhnk/system-clipboard.yazi |
+| Attribute name       | Short Description                                                                                                             | Upstream repo                                                                |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --- |
+| `bookmarks`          | A Yazi plugin that adds the basic functionality of vi-like marks                                                              | https://github.com/dedukun/bookmarks.yazi                                    |     |
+| `bypass`             | Skip directories with only a single sub-directory                                                                             | https://github.com/Rolv-Apneseth/bypass.yazi                                 |
+| `chmod`              | Execute chmod on the selected files to change their mode                                                                      | https://github.com/yazi-rs/plugins/tree/main/chmod.yazi                      |
+| `copy-file-contents` | Copy the contents of a file to clipboard directly from Yazi                                                                   | https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi |
+| `exifaudio`          | Preview audio files metadata on yazi                                                                                          | https://github.com/Sonico98/exifaudio.yazi                                   |
+| `full-border`        | Add a full border to Yazi to make it look fancier                                                                             | https://github.com/yazi-rs/plugins/tree/main/full-border.yazi                |
+| `glow`               | Plugin for Yazi to preview markdown files with glow                                                                           | https://github.com/Reledia/glow.yazi                                         |
+| `hide-preview`       | Switch the preview pane between hidden and shown                                                                              | https://github.com/yazi-rs/plugins/tree/main/hide-preview.yazi               |
+| `jump-to-char`       | Vim-like f<char>, jump to the next file whose name starts with <char>                                                         | https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi               |
+| `max-preview`        | Maximize or restore the preview pane                                                                                          | https://github.com/yazi-rs/plugins/tree/main/max-preview.yazi                |
+| `open-with-cmd`      | This is a Yazi plugin for opening files with a prompted command.                                                              | https://github.com/Ape/open-with-cmd.yazi                                    |
+| `ouch`               | A Yazi plugin to preview archives                                                                                             | https://github.com/ndtoan96/ouch.yazi                                        |
+| `relative-motions`   | basic vim motions like 3k, 12j, 10gg                                                                                          | https://github.com/dedukun/relative-motions.yazi                             |
+| `rich-preview`       | Rich preview plugin for yazi file manager                                                                                     | https://github.com/AnirudhG07/rich-preview.yazi                              |
+| `smart-filter`       | A Yazi plugin that makes filters smarter: continuous filtering, automatically enter unique directory, open file on submitting | https://github.com/yazi-rs/plugins/tree/main/smart-filter.yazi               |
+| `starship`           | Show starship prompt in header                                                                                                | https://github.com/Rolv-Apneseth/starship.yazi                               |
+| `system-clipboard`   | Cross platform implementation of a simple system clipboard for yazi file manager                                              | https://github.com/orhnk/system-clipboard.yazi                               |
 
 ## Contributing
+
 To request a new plugin or an update to an existing one, you can open an issue.
 Contributions are also welcome! Feel free to send PRs.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you run the release version, use the corresponding branch, for example `yazi-
 
 | Attribute name | Short Description | Upstream repo |
 | --- | --- | --- |
+| `bookmarks` | A Yazi plugin that adds the basic functionality of vi-like marks | https://github.com/dedukun/bookmarks.yazi |
 | `bypass` | Skip directories with only a single sub-directory | https://github.com/Rolv-Apneseth/bypass.yazi |
 | `chmod` | Execute chmod on the selected files to change their mode | https://github.com/yazi-rs/plugins/tree/main/chmod.yazi |
 | `copy-file-contents` | Copy the contents of a file to clipboard directly from Yazi | https://github.com/AnirudhG07/plugins-yazi/tree/main/copy-file-contents.yazi |
@@ -66,6 +67,7 @@ If you run the release version, use the corresponding branch, for example `yazi-
 | `hide-preview` | Switch the preview pane between hidden and shown | https://github.com/yazi-rs/plugins/tree/main/hide-preview.yazi |
 | `jump-to-char` | Vim-like f<char>, jump to the next file whose name starts with <char> | https://github.com/yazi-rs/plugins/tree/main/jump-to-char.yazi |
 | `max-preview` | Maximize or restore the preview pane | https://github.com/yazi-rs/plugins/tree/main/max-preview.yazi |
+| `open-with-cmd` | This is a Yazi plugin for opening files with a prompted command. | https://github.com/Ape/open-with-cmd.yazi |
 | `ouch` | A Yazi plugin to preview archives | https://github.com/ndtoan96/ouch.yazi |
 | `relative-motions` | basic vim motions like 3k, 12j, 10gg | https://github.com/dedukun/relative-motions.yazi |
 | `rich-preview` | Rich preview plugin for yazi file manager | https://github.com/AnirudhG07/rich-preview.yazi |

--- a/plugins/bookmarks/hm-module.nix
+++ b/plugins/bookmarks/hm-module.nix
@@ -10,12 +10,12 @@
       keys = {
         mark = mkKeyOption {
           on = [ "m" ];
-          run = "plugin bookmarks --args=save";
+          run = "plugin bookmarks save";
           desc = "Save current position as a bookmark";
         };
         jump = mkKeyOption {
           on = [ "'" ];
-          run = "plugin bookmarks --args=jump";
+          run = "plugin bookmarks jump";
           desc = "Jump to a bookmark";
         };
         delete = mkKeyOption {
@@ -23,7 +23,7 @@
             "b"
             "d"
           ];
-          run = "plugin bookmarks --args=delete";
+          run = "plugin bookmarks delete";
           desc = "Delete a bookmark";
         };
         delete_all = mkKeyOption {
@@ -31,7 +31,7 @@
             "b"
             "D"
           ];
-          run = "plugin bookmarks --args=delete_all";
+          run = "plugin bookmarks delete_all";
           desc = "Delete all bookmarks";
         };
       };

--- a/plugins/bookmarks/hm-module.nix
+++ b/plugins/bookmarks/hm-module.nix
@@ -26,15 +26,51 @@
         desc = "Delete all bookmarks";
       };
     };
+    persist = lib.mkOption {
+      type = with lib.types;
+        nullOr (enum [
+          "none"
+          "all"
+          "vim"
+        ]);
+      default = "none";
+      description = "When enabled the bookmarks will persist, i.e. if you close and reopen Yazi they will still be present.";
+    };
+    desc_format = lib.mkOption {
+      type = with lib.types;
+        nullOr (enum [
+          "full"
+          "parent"
+        ]);
+      default = "full";
+      description = "The format for the bookmark description.";
+    };
+    file_pick_mode = lib.mkOption {
+      type = with lib.types;
+        nullOr (enum [
+          "hover"
+          "parent"
+        ]);
+      default = "hover";
+      description = "The mode for choosing which directory to bookmark.";
+    };
   };
   config = {
     cfg,
     setKeys,
     ...
-  }: {
-    config,
-    lib,
-    ...
-  }:
-    {} // (setKeys cfg.keys);
+  }: {lib, ...}:
+    lib.mkMerge [
+      (setKeys cfg.keys)
+      {
+        programs.yazi.initLua = let
+          settings = {
+            inherit (cfg) persist desc_format file_pick_mode;
+          };
+          settingsStr = lib.generators.toLua {} settings;
+        in ''
+          require("bookmarks"):setup(${settingsStr})
+        '';
+      }
+    ];
 }

--- a/plugins/bookmarks/hm-module.nix
+++ b/plugins/bookmarks/hm-module.nix
@@ -1,0 +1,40 @@
+{
+  options = {
+    cfg,
+    mkKeyOption,
+    ...
+  }: {lib, ...}: {
+    keys = {
+      mark = mkKeyOption {
+        on = ["m"];
+        run = "plugin bookmarks --args=save";
+        desc = "Save current position as a bookmark";
+      };
+      jump = mkKeyOption {
+        on = ["'"];
+        run = "plugin bookmarks --args=jump";
+        desc = "Jump to a bookmark";
+      };
+      delete = mkKeyOption {
+        on = ["b" "d"];
+        run = "plugin bookmarks --args=delete";
+        desc = "Delete a bookmark";
+      };
+      delete_all = mkKeyOption {
+        on = ["b" "D"];
+        run = "plugin bookmarks --args=delete_all";
+        desc = "Delete all bookmarks";
+      };
+    };
+  };
+  config = {
+    cfg,
+    setKeys,
+    ...
+  }: {
+    config,
+    lib,
+    ...
+  }:
+    {} // (setKeys cfg.keys);
+}

--- a/plugins/bookmarks/hm-module.nix
+++ b/plugins/bookmarks/hm-module.nix
@@ -26,6 +26,10 @@
         desc = "Delete all bookmarks";
       };
     };
+    last_directory = {
+      enable = lib.mkEnableOption "When enabled, a new bookmark is automatically created in ' which allows the user to jump back to the last directory.";
+      persist = lib.mkEnableOption "When enabled the bookmarks will persist, i.e. if you close and reopen Yazi they will still be present.";
+    };
     persist = lib.mkOption {
       type = with lib.types;
         nullOr (enum [
@@ -54,6 +58,32 @@
       default = "hover";
       description = "The mode for choosing which directory to bookmark.";
     };
+    notify = {
+      enable =
+        lib.mkEnableOption "When enabled, notifications will be shown when the user creates a new bookmark and deletes one or all saved bookmarks.";
+      timeout = lib.mkOption {
+        type = with lib.types; int;
+        default = 1;
+        description = "The time a notification is displayed (in seconds)";
+      };
+      message = {
+        new = lib.mkOption {
+          type = with lib.types; str;
+          default = "New bookmark '<key>' -> '<folder>'";
+          description = "The notification message when creating a new bookmark";
+        };
+        delete = lib.mkOption {
+          type = with lib.types; str;
+          default = "Deleted bookmark in '<key>'";
+          description = "The notification message when deleting a bookmark";
+        };
+        delete_all = lib.mkOption {
+          type = with lib.types; str;
+          default = "Deleted all bookmarks";
+          description = "The notification message when deleting all bookmarks";
+        };
+      };
+    };
   };
   config = {
     cfg,
@@ -65,7 +95,7 @@
       {
         programs.yazi.initLua = let
           settings = {
-            inherit (cfg) persist desc_format file_pick_mode;
+            inherit (cfg) persist desc_format file_pick_mode last_directory notify;
           };
           settingsStr = lib.generators.toLua {} settings;
         in ''

--- a/plugins/bookmarks/hm-module.nix
+++ b/plugins/bookmarks/hm-module.nix
@@ -1,106 +1,127 @@
 {
-  options = {
-    cfg,
-    mkKeyOption,
-    ...
-  }: {lib, ...}: {
-    keys = {
-      mark = mkKeyOption {
-        on = ["m"];
-        run = "plugin bookmarks --args=save";
-        desc = "Save current position as a bookmark";
-      };
-      jump = mkKeyOption {
-        on = ["'"];
-        run = "plugin bookmarks --args=jump";
-        desc = "Jump to a bookmark";
-      };
-      delete = mkKeyOption {
-        on = ["b" "d"];
-        run = "plugin bookmarks --args=delete";
-        desc = "Delete a bookmark";
-      };
-      delete_all = mkKeyOption {
-        on = ["b" "D"];
-        run = "plugin bookmarks --args=delete_all";
-        desc = "Delete all bookmarks";
-      };
-    };
-    last_directory = {
-      enable = lib.mkEnableOption "When enabled, a new bookmark is automatically created in ' which allows the user to jump back to the last directory.";
-      persist = lib.mkEnableOption "When enabled the bookmarks will persist, i.e. if you close and reopen Yazi they will still be present.";
-    };
-    persist = lib.mkOption {
-      type = with lib.types;
-        nullOr (enum [
-          "none"
-          "all"
-          "vim"
-        ]);
-      default = "none";
-      description = "When enabled the bookmarks will persist, i.e. if you close and reopen Yazi they will still be present.";
-    };
-    desc_format = lib.mkOption {
-      type = with lib.types;
-        nullOr (enum [
-          "full"
-          "parent"
-        ]);
-      default = "full";
-      description = "The format for the bookmark description.";
-    };
-    file_pick_mode = lib.mkOption {
-      type = with lib.types;
-        nullOr (enum [
-          "hover"
-          "parent"
-        ]);
-      default = "hover";
-      description = "The mode for choosing which directory to bookmark.";
-    };
-    notify = {
-      enable =
-        lib.mkEnableOption "When enabled, notifications will be shown when the user creates a new bookmark and deletes one or all saved bookmarks.";
-      timeout = lib.mkOption {
-        type = with lib.types; int;
-        default = 1;
-        description = "The time a notification is displayed (in seconds)";
-      };
-      message = {
-        new = lib.mkOption {
-          type = with lib.types; str;
-          default = "New bookmark '<key>' -> '<folder>'";
-          description = "The notification message when creating a new bookmark";
+  options =
+    {
+      cfg,
+      mkKeyOption,
+      ...
+    }:
+    { lib, ... }:
+    {
+      keys = {
+        mark = mkKeyOption {
+          on = [ "m" ];
+          run = "plugin bookmarks --args=save";
+          desc = "Save current position as a bookmark";
         };
-        delete = lib.mkOption {
-          type = with lib.types; str;
-          default = "Deleted bookmark in '<key>'";
-          description = "The notification message when deleting a bookmark";
+        jump = mkKeyOption {
+          on = [ "'" ];
+          run = "plugin bookmarks --args=jump";
+          desc = "Jump to a bookmark";
         };
-        delete_all = lib.mkOption {
-          type = with lib.types; str;
-          default = "Deleted all bookmarks";
-          description = "The notification message when deleting all bookmarks";
+        delete = mkKeyOption {
+          on = [
+            "b"
+            "d"
+          ];
+          run = "plugin bookmarks --args=delete";
+          desc = "Delete a bookmark";
+        };
+        delete_all = mkKeyOption {
+          on = [
+            "b"
+            "D"
+          ];
+          run = "plugin bookmarks --args=delete_all";
+          desc = "Delete all bookmarks";
         };
       };
+      last_directory = {
+        enable = lib.mkEnableOption "When enabled, a new bookmark is automatically created in ' which allows the user to jump back to the last directory.";
+        persist = lib.mkEnableOption "When enabled the bookmarks will persist, i.e. if you close and reopen Yazi they will still be present.";
+      };
+      persist = lib.mkOption {
+        type =
+          with lib.types;
+          nullOr (enum [
+            "none"
+            "all"
+            "vim"
+          ]);
+        default = "none";
+        description = "When enabled the bookmarks will persist, i.e. if you close and reopen Yazi they will still be present.";
+      };
+      desc_format = lib.mkOption {
+        type =
+          with lib.types;
+          nullOr (enum [
+            "full"
+            "parent"
+          ]);
+        default = "full";
+        description = "The format for the bookmark description.";
+      };
+      file_pick_mode = lib.mkOption {
+        type =
+          with lib.types;
+          nullOr (enum [
+            "hover"
+            "parent"
+          ]);
+        default = "hover";
+        description = "The mode for choosing which directory to bookmark.";
+      };
+      notify = {
+        enable = lib.mkEnableOption "When enabled, notifications will be shown when the user creates a new bookmark and deletes one or all saved bookmarks.";
+        timeout = lib.mkOption {
+          type = with lib.types; int;
+          default = 1;
+          description = "The time a notification is displayed (in seconds)";
+        };
+        message = {
+          new = lib.mkOption {
+            type = with lib.types; str;
+            default = "New bookmark '<key>' -> '<folder>'";
+            description = "The notification message when creating a new bookmark";
+          };
+          delete = lib.mkOption {
+            type = with lib.types; str;
+            default = "Deleted bookmark in '<key>'";
+            description = "The notification message when deleting a bookmark";
+          };
+          delete_all = lib.mkOption {
+            type = with lib.types; str;
+            default = "Deleted all bookmarks";
+            description = "The notification message when deleting all bookmarks";
+          };
+        };
+      };
     };
-  };
-  config = {
-    cfg,
-    setKeys,
-    ...
-  }: {lib, ...}:
+  config =
+    {
+      cfg,
+      setKeys,
+      ...
+    }:
+    { lib, ... }:
     lib.mkMerge [
       (setKeys cfg.keys)
       {
-        programs.yazi.initLua = let
-          settings = {
-            inherit (cfg) persist desc_format file_pick_mode last_directory notify;
-          };
-          settingsStr = lib.generators.toLua {} settings;
-        in ''
-          require("bookmarks"):setup(${settingsStr})
-        '';
+        programs.yazi.initLua =
+          let
+            settings = {
+              inherit (cfg)
+                persist
+                desc_format
+                file_pick_mode
+                last_directory
+                notify
+                ;
+            };
+            settingsStr = lib.generators.toLua { } settings;
+          in
+          ''
+            require("bookmarks"):setup(${settingsStr})
+          '';
       }
     ];
 }

--- a/plugins/bookmarks/package.nix
+++ b/plugins/bookmarks/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "yaziPlugins-bookmarks";
+  version = "unstable-2025-01-21";
+
+  src = fetchFromGitHub {
+    owner = "dedukun";
+    repo = "bookmarks.yazi";
+    rev = "202e450b0088d3dde3c4a680f30cf9684acea1cc";
+    hash = "sha256-cPvNEanJpcVd+9Xaenu8aDAVk62CqAWbOq/jApwfBVE=";
+  };
+
+  buildPhase = ''
+    mkdir $out
+    cp $src/* $out
+  '';
+
+  meta = with lib; {
+    description = "A Yazi plugin that adds the basic functionality of vi-like marks.";
+    homepage = "https://github.com/dedukun/bookmarks.yazi";
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/bookmarks/package.nix
+++ b/plugins/bookmarks/package.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "dedukun";
     repo = "bookmarks.yazi";
-    rev = "420a384f51da9bc018530068679d2e826f9ce14b";
-    hash = "sha256-SBZQhdannSGQjU/m+xbuIrCxgM0mBZXGBVYSdYy9aR0=";
+    rev = "fe0b1de939fa49068ac6b35da8d6680799931f1c";
+    hash = "sha256-5ZW73yHKEfKmN/JsZUINUVyEwvK4bA4DlufRgdT1toI=";
   };
 
   buildPhase = ''

--- a/plugins/bookmarks/package.nix
+++ b/plugins/bookmarks/package.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation {
   pname = "yaziPlugins-bookmarks";
-  version = "unstable-2025-01-21";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "dedukun";
     repo = "bookmarks.yazi";
-    rev = "202e450b0088d3dde3c4a680f30cf9684acea1cc";
-    hash = "sha256-cPvNEanJpcVd+9Xaenu8aDAVk62CqAWbOq/jApwfBVE=";
+    rev = "420a384f51da9bc018530068679d2e826f9ce14b";
+    hash = "sha256-SBZQhdannSGQjU/m+xbuIrCxgM0mBZXGBVYSdYy9aR0=";
   };
 
   buildPhase = ''

--- a/plugins/bookmarks/package.nix
+++ b/plugins/bookmarks/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
     description = "A Yazi plugin that adds the basic functionality of vi-like marks.";
     homepage = "https://github.com/dedukun/bookmarks.yazi";
     license = licenses.mit;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/plugins/open-with-cmd/hm-module.nix
+++ b/plugins/open-with-cmd/hm-module.nix
@@ -4,12 +4,12 @@
     _: {
       keys = {
         open_terminal = mkKeyOption {
-          on = "o";
+          on = [ "o" ];
           run = "plugin open-with-cmd block";
           desc = "Open with command in the terminal";
         };
         open = mkKeyOption {
-          on = "O";
+          on = [ "O" ];
           run = "plugin open-with-cmd";
           desc = "Open with command";
         };

--- a/plugins/open-with-cmd/hm-module.nix
+++ b/plugins/open-with-cmd/hm-module.nix
@@ -5,7 +5,7 @@
       keys = {
         open_terminal = mkKeyOption {
           on = "o";
-          run = "plugin open-with-cmd --args=block";
+          run = "plugin open-with-cmd block";
           desc = "Open with command in the terminal";
         };
         open = mkKeyOption {

--- a/plugins/open-with-cmd/hm-module.nix
+++ b/plugins/open-with-cmd/hm-module.nix
@@ -1,21 +1,25 @@
 {
-  options = {mkKeyOption, ...}: _: {
-    keys = {
-      open_terminal = mkKeyOption {
-        on = "o";
-        run = "plugin open-with-cmd --args=block";
-        desc = "Open with command in the terminal";
-      };
-      open = mkKeyOption {
-        on = "O";
-        run = "plugin open-with-cmd";
-        desc = "Open with command";
+  options =
+    { mkKeyOption, ... }:
+    _: {
+      keys = {
+        open_terminal = mkKeyOption {
+          on = "o";
+          run = "plugin open-with-cmd --args=block";
+          desc = "Open with command in the terminal";
+        };
+        open = mkKeyOption {
+          on = "O";
+          run = "plugin open-with-cmd";
+          desc = "Open with command";
+        };
       };
     };
-  };
-  config = {
-    cfg,
-    setKeys,
-    ...
-  }: _: (setKeys cfg.keys);
+  config =
+    {
+      cfg,
+      setKeys,
+      ...
+    }:
+    _: (setKeys cfg.keys);
 }

--- a/plugins/open-with-cmd/hm-module.nix
+++ b/plugins/open-with-cmd/hm-module.nix
@@ -1,0 +1,21 @@
+{
+  options = {mkKeyOption, ...}: _: {
+    keys = {
+      open_terminal = mkKeyOption {
+        on = "o";
+        run = "plugin open-with-cmd --args=block";
+        desc = "Open with command in the terminal";
+      };
+      open = mkKeyOption {
+        on = "O";
+        run = "plugin open-with-cmd";
+        desc = "Open with command";
+      };
+    };
+  };
+  config = {
+    cfg,
+    setKeys,
+    ...
+  }: _: (setKeys cfg.keys);
+}

--- a/plugins/open-with-cmd/package.nix
+++ b/plugins/open-with-cmd/package.nix
@@ -5,13 +5,13 @@
 }:
 stdenv.mkDerivation {
   pname = "yaziPlugins-open-with-cmd";
-  version = "unstable-2025-01-21";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "Ape";
     repo = "open-with-cmd.yazi";
-    rev = "a80d1cf41fc23f84fbdf0b8b26c5b13f06455472";
-    hash = "sha256-IAJSZhO6WEIjSXlUvmcX3rgpQKu358vfe5dEm7JtmPg=";
+    rev = "433cf301c36882c31032d3280ab0c94825fc5e9f";
+    hash = "sha256-QazKfNEPFdkHwMrH4D+VMwj8fGXM8KHDdSvm1tik3dQ=";
   };
 
   buildPhase = ''

--- a/plugins/open-with-cmd/package.nix
+++ b/plugins/open-with-cmd/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     description = "This is a Yazi plugin for opening files with a prompted command.";
     homepage = "https://github.com/Ape/open-with-cmd.yazi";
     license = licenses.mit;
-    maintainers = [];
+    maintainers = [ ];
     platforms = platforms.all;
   };
 }

--- a/plugins/open-with-cmd/package.nix
+++ b/plugins/open-with-cmd/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "yaziPlugins-open-with-cmd";
+  version = "unstable-2025-01-21";
+
+  src = fetchFromGitHub {
+    owner = "Ape";
+    repo = "open-with-cmd.yazi";
+    rev = "a80d1cf41fc23f84fbdf0b8b26c5b13f06455472";
+    hash = "sha256-IAJSZhO6WEIjSXlUvmcX3rgpQKu358vfe5dEm7JtmPg=";
+  };
+
+  buildPhase = ''
+    mkdir $out
+    cp $src/* $out
+  '';
+  meta = with lib; {
+    description = "This is a Yazi plugin for opening files with a prompted command.";
+    homepage = "https://github.com/Ape/open-with-cmd.yazi";
+    license = licenses.mit;
+    maintainers = [];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
- **feat: Add plugin: Bookmarks**
- **feat: Add plugin: open-with-cmd**

I think I'm using a different formatter then you guys ._.
I named the key binds using under_scores; I didn't know which convention to use.

In Bookmarks, the marks are not persistent by default; one has to change the init parameters, i.e.
```nix
require("bookmarks"):setup({
	last_directory = { enable = true, persist = false },
	persist = "vim",
	desc_format = "parent",
	notify = {
		enable = true,
		timeout = 1,
		message = {
			new = "New bookmark '<key>' -> '<folder>'",
			delete = "Deleted bookmark in '<key>'",
			delete_all = "Deleted all bookmarks",
		},
	},
})
```

resolves #10 