### PR TITLE
feat: add `extraConfig` option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,11 @@
                           default = self.packages.${pkgs.system}.${v.name};
                         };
                         enable = mkEnableOption v.name;
+                        extraConfig = mkOption {
+                          type = lib.types.lines;
+                          description = "Extra configuration lines to add to ~/.config/yazi/init.lua for ${v.name}";
+                          default = '''';
+                        };
                       };
                     }
                   )

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,11 @@
                       programs.yazi.yaziPlugins.requiredPlugins = cfg.requiredPlugins;
                     };
                   })
+                  (_: {
+                    config = lib.mkIf (cfg.enable && cfg ? "extraConfig") {
+                      programs.yazi.yaziPlugins.extraConfig = cfg.extraConfig;
+                    };
+                  })
                   (inputs: (v.options ({ inherit cfg; } // (import ./lib.nix inputs))) inputs)
                   (
                     { pkgs, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
                     };
                   })
                   (_: {
-                    config = lib.mkIf (cfg.enable && cfg ? "extraConfig") {
+                    config = lib.mkIf (cfg.enable && cfg ? "extraConfig" && cfg.extraConfig != "") {
                       programs.yazi.yaziPlugins.extraConfig = cfg.extraConfig;
                     };
                   })

--- a/flake.nix
+++ b/flake.nix
@@ -78,8 +78,8 @@
                     };
                   })
                   (_: {
-                    config = lib.mkIf (cfg.enable && cfg ? "requiredPlugins") {
-                      programs.yazi.yaziPlugins.requiredPlugins = cfg.requiredPlugins;
+                    config = lib.mkIf (cfg.enable && cfg ? "require") {
+                      programs.yazi.yaziPlugins.require = cfg.require;
                     };
                   })
                   (_: {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,11 @@
                       programs.yazi.yaziPlugins.runtimeDeps = cfg.runtimeDeps;
                     };
                   })
+                  (_: {
+                    config = lib.mkIf (cfg.enable && cfg ? "requiredPlugins") {
+                      programs.yazi.yaziPlugins.requiredPlugins = cfg.requiredPlugins;
+                    };
+                  })
                   (inputs: (v.options ({ inherit cfg; } // (import ./lib.nix inputs))) inputs)
                   (
                     { pkgs, ... }:

--- a/module.nix
+++ b/module.nix
@@ -51,6 +51,11 @@ in
       '';
       default = [ ];
     };
+    extraConfig = mkOption {
+      type = lib.types.lines;
+      description = "Extra configuration lines to add to ~/.config/yazi/init.lua";
+      default = '''';
+    };
   };
   config = lib.mkIf (cfg.runtimeDeps != [ ]) {
     programs.yazi.package = pkgs.yazi.override {

--- a/module.nix
+++ b/module.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (lib) mkEnableOption mkOption;
-  inherit (lib.types) lines;
   cfg = config.programs.yazi.yaziPlugins;
 in
 {
@@ -17,6 +16,36 @@ in
       description = ''
         Additional runtime packages to make available for yazi and plugins.
         To deactivate overlaying set this to `lib.mkForce []`.
+
+        This gets set by some plugin modules.
+      '';
+      default = [ ];
+    };
+    requiredPlugins = mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            name = mkOption {
+              type = lib.types.str;
+              description = "Name of the plugin to be `require`d";
+              example = "relative-motions";
+            };
+            setup = mkOption {
+              type = lib.types.nullOr lib.types.attrs;
+              description = "Optional settings to pass to the plugin's `setup()` function";
+              example = lib.literalExpression ''
+                {
+                  show_numbers = "relative_absolute";
+                  show_motion = true;
+                }
+              '';
+            };
+          };
+        }
+      );
+      description = ''
+        Plugins that need to be `require`d in ~/.config/yazi/init.lua with optional setup settings.
+        To deactivate automatically setting up applicable plugins, set this to `lib.mkForce []`.
 
         This gets set by some plugin modules.
       '';

--- a/plugins/full-border/hm-module.nix
+++ b/plugins/full-border/hm-module.nix
@@ -1,9 +1,5 @@
 {
   config = _: _: {
-    programs.yazi.yaziPlugins.requiredPlugins = [
-      {
-        name = "full-border";
-      }
-    ];
+    programs.yazi.yaziPlugins.require."full-border" = { };
   };
 }

--- a/plugins/full-border/hm-module.nix
+++ b/plugins/full-border/hm-module.nix
@@ -1,7 +1,9 @@
 {
   config = _: _: {
-    programs.yazi.initLua = ''
-      require("full-border"):setup()
-    '';
+    programs.yazi.yaziPlugins.requiredPlugins = [
+      {
+        name = "full-border";
+      }
+    ];
   };
 }

--- a/plugins/relative-motions/hm-module.nix
+++ b/plugins/relative-motions/hm-module.nix
@@ -41,16 +41,14 @@
     lib.mkMerge [
       (setKeys cfg.keys)
       {
-        programs.yazi.initLua =
-          let
-            settings = {
+        programs.yazi.yaziPlugins.requiredPlugins = [
+          {
+            name = "relative-motions";
+            setup = {
               inherit (cfg) show_numbers show_motion only_motions;
             };
-            settingsStr = lib.generators.toLua { } settings;
-          in
-          ''
-            require("relative-motions"):setup(${settingsStr})
-          '';
+          }
+        ];
       }
     ];
 }

--- a/plugins/relative-motions/hm-module.nix
+++ b/plugins/relative-motions/hm-module.nix
@@ -41,14 +41,9 @@
     lib.mkMerge [
       (setKeys cfg.keys)
       {
-        programs.yazi.yaziPlugins.requiredPlugins = [
-          {
-            name = "relative-motions";
-            setup = {
-              inherit (cfg) show_numbers show_motion only_motions;
-            };
-          }
-        ];
+        programs.yazi.yaziPlugins.require."relative-motions" = {
+          inherit (cfg) show_numbers show_motion only_motions;
+        };
       }
     ];
 }

--- a/plugins/starship/hm-module.nix
+++ b/plugins/starship/hm-module.nix
@@ -1,9 +1,5 @@
 {
   config = _: _: {
-    programs.yazi.yaziPlugins.requiredPlugins = [
-      {
-        name = "starship";
-      }
-    ];
+    programs.yazi.yaziPlugins.require.starship = { };
   };
 }

--- a/plugins/starship/hm-module.nix
+++ b/plugins/starship/hm-module.nix
@@ -1,7 +1,9 @@
 {
   config = _: _: {
-    programs.yazi.initLua = ''
-      require("starship"):setup()
-    '';
+    programs.yazi.yaziPlugins.requiredPlugins = [
+      {
+        name = "starship";
+      }
+    ];
   };
 }


### PR DESCRIPTION
Currently, there is no way to for users to add extra code to `programs.yazi.initLua` if they are using any of the plugins that depend on using `require()` and running a setup function in init.lua, namely full-border, relative-motions, and starship.

In addition, using more than one of these plugins causes a conflict when nix tries to evaluate it.

This PR remedies both of these problems.

I added an `extraConfig` option for any extra Lua code that a user wishes to include after the setup functions, similar to various other programs that have home manager modules.

I also added an option, `requiredPlugins`, for plugins that need to be `require`d and run a setup function. It takes a list of attrsets that have two attributes, `name`, the plugin's name, and `setup`, for any options that need to be passed to `setup()`. I was not sure what to name this, and I am more than happy to change it if you think a different name would suit it better.