### PR TITLE
feat: update plugins to use new api

### DIFF
--- a/plugins/bypass/hm-module.nix
+++ b/plugins/bypass/hm-module.nix
@@ -6,12 +6,12 @@
       keys = {
         left = mkKeyOption {
           on = [ "l" ];
-          run = "plugin bypass --args=smart_enter";
+          run = "plugin bypass smart_enter";
           desc = "Open a file, or recursively enter child directory, skipping children with only a single subdirectory";
         };
         right = mkKeyOption {
           on = [ "h" ];
-          run = "plugin bypass --args=reverse";
+          run = "plugin bypass reverse";
           desc = "Recursively enter parent directory, skipping parents with only a single subdirectory";
         };
       };

--- a/plugins/bypass/package.nix
+++ b/plugins/bypass/package.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
   version = "unstable-2024-12-14";
 
   src = fetchFromGitHub {
-    owner = "Rolv-Apneseth";
+    owner = "haennes";
     repo = "bypass.yazi";
-    rev = "6c5414f532ede57a74687c53fee3409a38746c04";
-    sha256 = "sha256-jzE6U9RgRF0oy4HQ91WjoftZ47EXPwb7bRtlVwL8vOQ=";
+    rev = "d8a7b7f1b75f86d507f358ffe9155ca12f1f3a28";
+    sha256 = "sha256-XvVz+8sLG2gJnUUQDFofu/EsGewSB4heVTz8P3CSwGk=";
   };
 
   buildPhase = ''

--- a/plugins/bypass/package.nix
+++ b/plugins/bypass/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-bypass";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";

--- a/plugins/bypass/package.nix
+++ b/plugins/bypass/package.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
   version = "unstable-2024-12-14";
 
   src = fetchFromGitHub {
-    owner = "haennes";
+    owner = "Rolv-Apneseth";
     repo = "bypass.yazi";
-    rev = "d8a7b7f1b75f86d507f358ffe9155ca12f1f3a28";
-    sha256 = "sha256-XvVz+8sLG2gJnUUQDFofu/EsGewSB4heVTz8P3CSwGk=";
+    rev = "ecb1f7f6fd305ff4ffff548fa955595af6b26e60";
+    sha256 = "sha256-XXp4XflrVrs8FrUCRUbSxWZTSGPrIGrpqvB1pARerKQ=";
   };
 
   buildPhase = ''

--- a/plugins/chmod/package.nix
+++ b/plugins/chmod/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-chmod";
-  version = "unstable-2024-08-21";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";

--- a/plugins/chmod/package.nix
+++ b/plugins/chmod/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "b6597919540731691158831bf1ff36ed38c1964e";
-    sha256 = "07dm70s48mas4d38zhnrfw9p3sgk83ki70xi1jb2d191ya7a2p3j";
+    rev = "beb586aed0d41e6fdec5bba7816337fdad905a33";
+    sha256 = "sha256-enIt79UvQnKJalBtzSEdUkjNHjNJuKUWC4L6QFb3Ou4=";
   };
 
   buildPhase = ''

--- a/plugins/copy-file-contents/package.nix
+++ b/plugins/copy-file-contents/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-copy-file-contents";
-  version = "unstable-2024-11-20";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";

--- a/plugins/copy-file-contents/package.nix
+++ b/plugins/copy-file-contents/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "plugins-yazi";
-    rev = "f871a9c0b9322f9882ea7613015e68f618f4e15f";
-    hash = "sha256-OSS+EWOoRumVdy2lN86jmi14tR+b0VsvfwVn5ka4GPg=";
+    rev = "524c52c7e433834e36a502abd1e31a6a65c8caf0";
+    hash = "sha256-GrPqcHYG+qHNi80U+EJJd1JjdAOexiE6sQxsqdeCSMg=";
   };
 
   buildPhase = ''

--- a/plugins/exifaudio/package.nix
+++ b/plugins/exifaudio/package.nix
@@ -9,9 +9,9 @@ stdenv.mkDerivation {
   version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
-    owner = "haennes";
+    owner = "Sonico98";
     repo = "exifaudio.yazi";
-    rev = "6bc168bfe664c75cb943089f72b1b8cdf61b9e0b";
+    rev = "4379fcfa2dbe0b81fde2dd67b9ac2e0e48331419";
     hash = "sha256-CIimJU4KaKyaKBuiBvcRJUJqTG8pkGyytT6bPf/x8j8=";
   };
   buildPhase = ''

--- a/plugins/exifaudio/package.nix
+++ b/plugins/exifaudio/package.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
   version = "unstable-2024-11-23";
 
   src = fetchFromGitHub {
-    owner = "Sonico98";
+    owner = "haennes";
     repo = "exifaudio.yazi";
-    rev = "855ff055c11fb8f268b4c006a8bd59dd9bcf17a7";
-    hash = "sha256-8f1iG9RTLrso4S9mHYcm3dLKWXd/WyRzZn6KNckmiCc=";
+    rev = "6bc168bfe664c75cb943089f72b1b8cdf61b9e0b";
+    hash = "sha256-CIimJU4KaKyaKBuiBvcRJUJqTG8pkGyytT6bPf/x8j8=";
   };
   buildPhase = ''
     mkdir $out

--- a/plugins/exifaudio/package.nix
+++ b/plugins/exifaudio/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-exifaudio";
-  version = "unstable-2024-11-23";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "haennes";

--- a/plugins/full-border/package.nix
+++ b/plugins/full-border/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "62f078905b4de55f19e328452c8a1f889ff2f6f4";
-    sha256 = "sha256-PSVzjC1sdaIOtK5ave4kn3Ck8YwpjO3N9uV/WE6Skdo=";
+    rev = "beb586aed0d41e6fdec5bba7816337fdad905a33";
+    sha256 = "sha256-enIt79UvQnKJalBtzSEdUkjNHjNJuKUWC4L6QFb3Ou4=";
   };
 
   buildPhase = ''

--- a/plugins/full-border/package.nix
+++ b/plugins/full-border/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-full-border";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";

--- a/plugins/glow/package.nix
+++ b/plugins/glow/package.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
   version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
-    owner = "loqusion";
+    owner = "Reledia";
     repo = "glow.yazi";
-    rev = "39d621a5d1308103690fee04b9840b8395410fdf";
-    hash = "sha256-1k2bOXHwsDxpgLVMOA2TW+WbJoIOb+3qj322oObHnAs=";
+    rev = "c76bf4fb612079480d305fe6fe570bddfe4f99d3";
+    hash = "sha256-DPud1Mfagl2z490f5L69ZPnZmVCa0ROXtFeDbEegBBU=";
   };
 
   buildPhase = ''

--- a/plugins/glow/package.nix
+++ b/plugins/glow/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-glow";
-  version = "unstable-2024-11-21";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "loqusion";

--- a/plugins/glow/package.nix
+++ b/plugins/glow/package.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
   version = "unstable-2024-11-21";
 
   src = fetchFromGitHub {
-    owner = "Reledia";
+    owner = "loqusion";
     repo = "glow.yazi";
-    rev = "388e847dca6497cf5903f26ca3b87485b2de4680";
-    hash = "sha256-fKJ5ld5xc6HsM/h5j73GABB5i3nmcwWCs+QSdDPA9cU=";
+    rev = "39d621a5d1308103690fee04b9840b8395410fdf";
+    hash = "sha256-1k2bOXHwsDxpgLVMOA2TW+WbJoIOb+3qj322oObHnAs=";
   };
 
   buildPhase = ''

--- a/plugins/hide-preview/package.nix
+++ b/plugins/hide-preview/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "62f078905b4de55f19e328452c8a1f889ff2f6f4";
-    sha256 = "sha256-PSVzjC1sdaIOtK5ave4kn3Ck8YwpjO3N9uV/WE6Skdo=";
+    rev = "beb586aed0d41e6fdec5bba7816337fdad905a33";
+    sha256 = "sha256-enIt79UvQnKJalBtzSEdUkjNHjNJuKUWC4L6QFb3Ou4=";
   };
 
   buildPhase = ''

--- a/plugins/hide-preview/package.nix
+++ b/plugins/hide-preview/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-hide-preview";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";

--- a/plugins/jump-to-char/package.nix
+++ b/plugins/jump-to-char/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "62f078905b4de55f19e328452c8a1f889ff2f6f4";
-    sha256 = "sha256-PSVzjC1sdaIOtK5ave4kn3Ck8YwpjO3N9uV/WE6Skdo=";
+    rev = "beb586aed0d41e6fdec5bba7816337fdad905a33";
+    sha256 = "sha256-enIt79UvQnKJalBtzSEdUkjNHjNJuKUWC4L6QFb3Ou4=";
   };
 
   buildPhase = ''

--- a/plugins/jump-to-char/package.nix
+++ b/plugins/jump-to-char/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-jump-to-char";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";

--- a/plugins/max-preview/package.nix
+++ b/plugins/max-preview/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "62f078905b4de55f19e328452c8a1f889ff2f6f4";
-    sha256 = "sha256-PSVzjC1sdaIOtK5ave4kn3Ck8YwpjO3N9uV/WE6Skdo=";
+    rev = "beb586aed0d41e6fdec5bba7816337fdad905a33";
+    sha256 = "sha256-enIt79UvQnKJalBtzSEdUkjNHjNJuKUWC4L6QFb3Ou4=";
   };
 
   buildPhase = ''

--- a/plugins/max-preview/package.nix
+++ b/plugins/max-preview/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-max-preview";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";

--- a/plugins/ouch/package.nix
+++ b/plugins/ouch/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "ndtoan96";
     repo = "ouch.yazi";
-    rev = "db1488358941a2bc9918fa91c304d6724a0bb608";
-    hash = "sha256-fEfsHEddL7bg4z85UDppspVGlfUJIa7g11BwjHbufrE=";
+    rev = "ce6fb75431b9d0d88efc6ae92e8a8ebb9bc1864a";
+    hash = "sha256-oUEUGgeVbljQICB43v9DeEM3XWMAKt3Ll11IcLCS/PA=";
   };
 
   buildPhase = ''

--- a/plugins/ouch/package.nix
+++ b/plugins/ouch/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-ouch";
-  version = "unstable-2024-11-20";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "ndtoan96";

--- a/plugins/relative-motions/hm-module.nix
+++ b/plugins/relative-motions/hm-module.nix
@@ -13,7 +13,7 @@
             name = idx;
             value = mkKeyOption {
               on = [ idx ];
-              run = "plugin relative-motions --args=${idx}";
+              run = "plugin relative-motions ${idx}";
               desc = "Move in relative steps";
             };
           }

--- a/plugins/relative-motions/package.nix
+++ b/plugins/relative-motions/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-relative-motions";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "dedukun";

--- a/plugins/relative-motions/package.nix
+++ b/plugins/relative-motions/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "dedukun";
     repo = "relative-motions.yazi";
-    rev = "df97039a04595a40a11024f321a865b3e9af5092";
-    sha256 = "sha256-csX8T2a5f7k6g2mlR+08rm0qBeWdI4ABuja+klIvwqw=";
+    rev = "0d9c8cfae8d1f74227808150a0666bcbb1114d0e";
+    sha256 = "sha256-wWOrPwQiJP1F/gqXPGrvKnNc1SSac4/9cDPdHjOgkOw=";
   };
 
   buildPhase = ''

--- a/plugins/rich-preview/package.nix
+++ b/plugins/rich-preview/package.nix
@@ -5,7 +5,7 @@
 }:
 stdenv.mkDerivation {
   pname = "yaziPlugins-rich-preview";
-  version = "unstable-2024-11-23";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "AnirudhG07";

--- a/plugins/rich-preview/package.nix
+++ b/plugins/rich-preview/package.nix
@@ -10,8 +10,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "AnirudhG07";
     repo = "rich-preview.yazi";
-    rev = "fe432192db970b5c3f8a9f037280c7431d9c2abe";
-    hash = "sha256-sKKdZJxPcbGy9lMhnwbklWEhUjYArVhQyoiH3kuMVzY=";
+    rev = "2559e5fa7c1651dbe7c5615ef6f3b5291347d81a";
+    hash = "sha256-dW2gAAv173MTcQdqMV32urzfrsEX6STR+oCJoRVGGpA=";
   };
 
   buildPhase = ''

--- a/plugins/smart-filter/package.nix
+++ b/plugins/smart-filter/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "62f078905b4de55f19e328452c8a1f889ff2f6f4";
-    sha256 = "sha256-PSVzjC1sdaIOtK5ave4kn3Ck8YwpjO3N9uV/WE6Skdo=";
+    rev = "beb586aed0d41e6fdec5bba7816337fdad905a33";
+    sha256 = "sha256-enIt79UvQnKJalBtzSEdUkjNHjNJuKUWC4L6QFb3Ou4=";
   };
 
   buildPhase = ''

--- a/plugins/smart-filter/package.nix
+++ b/plugins/smart-filter/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-smart-filter";
-  version = "unstable-2024-08-21";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";

--- a/plugins/starship/package.nix
+++ b/plugins/starship/package.nix
@@ -11,8 +11,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";
     repo = "starship.yazi";
-    rev = "247f49da1c408235202848c0897289ed51b69343";
-    sha256 = "sha256-0J6hxcdDX9b63adVlNVWysRR5htwAtP5WhIJ2AK2+Gs=";
+    rev = "f6939fbdbc3fdfcdc2a80251841e429e0cd5cf3c";
+    sha256 = "sha256-5QQsFozbulgLY/Gl6QuKSOTtygULveoRD49V00e0WOw=";
   };
 
   buildPhase = ''

--- a/plugins/starship/package.nix
+++ b/plugins/starship/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-starship";
-  version = "unstable-2024-12-14";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "Rolv-Apneseth";

--- a/plugins/system-clipboard/package.nix
+++ b/plugins/system-clipboard/package.nix
@@ -9,10 +9,10 @@ stdenv.mkDerivation {
   version = "unstable-2024-11-23";
 
   src = fetchFromGitHub {
-    owner = "orhnk";
+    owner = "haennes";
     repo = "system-clipboard.yazi";
-    rev = "7775a80e8d3391e0b3da19ba143196960a4efc48";
-    hash = "sha256-tfR9XHvRqm7yPbTu/joBDpu908oceaUoBiIImehMobk=";
+    rev = "fbf979b088b970d6af7f60364e98b4a7c631b51f";
+    hash = "sha256-zOQQvbkXq71t2E4x45oM4MzVRlZ4hhe6RkvgcP8tdYE=";
   };
 
   buildPhase = ''

--- a/plugins/system-clipboard/package.nix
+++ b/plugins/system-clipboard/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "yaziPlugins-system-clipboard";
-  version = "unstable-2024-11-23";
+  version = "unstable-2025-02-18";
 
   src = fetchFromGitHub {
     owner = "haennes";


### PR DESCRIPTION
- change all invocations of `plugin PLUGIN --args=SOMEARGS` to `plugin PLUGIN SOMEARGS
- update all plugins to use main.lua as a entry point (it was init.lua previously)