### PR TITLE
New plugin - yamb

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
         # -> bypass = ...
         CondRaiseAttrs = n: set: mapAttrs (_n: v: v."${n}") (filterAttrs (_n: v: v ? "${n}") set);
 
-        packages = if (pkgs ? yaziPlugins) then pkgs.yaziPlugins// packagesOurs else packagesOurs;
+        packages = if (pkgs ? yaziPlugins) then pkgs.yaziPlugins // packagesOurs else packagesOurs;
         packagesOurs = (CondRaiseAttrs "package" YaziPlugins);
 
         homeManagerModulesRaised = (CondRaiseAttrs "hm-module" YaziPlugins);
@@ -88,7 +88,7 @@
                       programs.yazi.yaziPlugins.extraConfig = cfg.extraConfig;
                     };
                   })
-                  (inputs: (v.options ({ inherit cfg; } // (import ./lib.nix inputs))) inputs)
+                  (inputs: (v.options ({ inherit cfg pkgs; } // (import ./lib.nix inputs))) inputs)
                   (
                     { pkgs, ... }:
                     {

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
                       programs.yazi.yaziPlugins.extraConfig = cfg.extraConfig;
                     };
                   })
-                  (inputs: (v.options ({ inherit cfg pkgs; } // (import ./lib.nix inputs))) inputs)
+                  ({ pkgs, ... }@inputs: (v.options ({ inherit cfg; } // (import ./lib.nix inputs))) inputs)
                   (
                     { pkgs, ... }:
                     {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -133,7 +133,7 @@
           # yambConfig.cli is either string or package:
           # if string, just insert the option
           # if package, add it to runtimeDeps and get the executable from the package
-          requre.yamb = yambConfig // {
+          require.yamb = yambConfig // {
             cli = if builtins.isString yambConfig.cli then yambConfig.cli else lib.getExe yambConfig.cli;
           };
           runtimeDeps = if builtins.isString yambConfig.cli then [ ] else [ yambConfig.cli ];

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -80,7 +80,24 @@
         };
       };
       bookmarks = lib.mkOption {
-        type = with lib.types; listOf attrs;
+        type =
+          with lib.types;
+          listOf (submodule {
+            options = {
+              tag = lib.mkOption {
+                type = with lib.types; str;
+                description = "A Tag / Name for a bookmark";
+              };
+              path = lib.mkOption {
+                type = with lib.types; either str path;
+                description = "The path of the bookmarked item";
+              };
+              key = lib.mkOption {
+                type = with lib.types; strMatching "^.$"; # single char
+                description = "A shortcut to jump to the bookmarks quickly";
+              };
+            };
+          });
         description = "Declarative bookmarks for yamb";
         example = [
           {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -81,7 +81,7 @@
       };
       bookmarks = lib.mkOption {
         type = with lib.types; listOf attrs;
-        description = "Declarative bookmarks";
+        description = "Declarative bookmarks for yamb";
         example = [
           {
             tag = "Desktop";
@@ -98,12 +98,12 @@
       };
       cli = lib.mkOption {
         type = with lib.types; either package str;
-        description = "The cli for fzf: either a package containing an executable or a string that gives the name of package in nixpkgs that contains an executable.";
+        description = "The CLI for fzf: either a string containing the command to be executed, or package containing an executable. If this option is a package, the package will be included as a runtime dependancy for yamb and the executable in the package will be used as the CLI command.";
         example = [
           "fzf"
           pkgs.fzf
         ];
-        default = "fzf";
+        default = pkgs.fzf;
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";
@@ -130,12 +130,13 @@
       (setKeys cfg.hotkeys)
       {
         programs.yazi.yaziPlugins = {
-          require.yamb = yambConfig // {
-            cli = lib.getExe (
-              if builtins.isString yambConfig.cli then pkgs."${yambConfig.cli}" else yambConfig.cli
-            ); # get the executable path from the package
+          # yambConfig.cli is either string or package:
+          # if string, just insert the option
+          # if package, add it to runtimeDeps and get the executable from the package
+          requre.yamb = yambConfig // {
+            cli = if builtins.isString yambConfig.cli then yambConfig.cli else lib.getExe yambConfig.cli;
           };
-          runtimeDeps = [ yambConfig.cli ]; # runtimeDeps expects a list here
+          runtimeDeps = if builtins.isString yambConfig.cli then [ ] else [ yambConfig.cli ];
         };
       }
     ];

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -121,16 +121,22 @@
     lib.mkMerge [
       (setKeys cfg.keys)
       {
-        programs.yazi.yaziPlugins.require.yamb = with nonNullCfg; {
-          inherit
-            bookmarks
-            jump_notify
-            cli
-            path
-            ;
-          ${if bookmarkKeys == null then keys else null} = bookmarkKeys;
-          # ${if path != null then path else null} = path;
-        };
+        programs.yazi.yaziPlugins.require.yamb =
+          with nonNullCfg;
+          let
+            keys = bookmarkKeys;
+          in
+          {
+            inherit
+              bookmarks
+              jump_notify
+              cli
+              path
+              keys
+              ;
+            # ${if bookmarkKeys == null then keys else null} = bookmarkKeys;
+            # ${if path != null then path else null} = path;
+          };
       }
     ];
 }

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -84,28 +84,28 @@
             key = "d";
           }
         ];
-        # default = [ ];
+        default = [ ];
       };
       jump_notify = lib.mkOption {
         type = with lib.types; bool;
         description = "Recieve notification everytime you jump.";
-        # default = true;
+        default = true;
       };
       cli = lib.mkOption {
         type = with lib.types; str;
         description = "The cli for fzf";
-        # default = "fzf";
+        default = "fzf";
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";
         description = "A string used for randomly generating keys, where the preceding characters have higher priority";
-        # default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
       };
       path = lib.mkOption {
         type = with lib.types; nullOr str;
         description = "The path of bookmarks";
-        # default = "~/.config/yazi/bookmark";
-        default = null;
+        default = "/home/zane/.config/yazi/bookmark";
+        # default = null;
       };
     };
   config =

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -116,21 +116,22 @@
     }:
     { lib, ... }:
     let
-      nonNullCfg = lib.attrsets.filterAttrs (name: val: val == null) cfg;
+      yambConfig = lib.attrsets.filterAttrs (name: val: val == null || name == "hotkeys") cfg;
     in
     lib.mkMerge [
       (setKeys cfg.hotkeys)
       {
-        programs.yazi.yaziPlugins.require.yamb = with nonNullCfg; {
-          inherit
-            bookmarks
-            jump_notify
-            cli
-            path
-            keys
-            ;
-          # ${if path != null then path else null} = path;
-        };
+        programs.yazi.yaziPlugins.require.yamb = yambConfig;
+        # {
+        #   inherit (yambConfig)
+        #     bookmarks
+        #     jump_notify
+        #     cli
+        #     path
+        #     keys
+        #     ;
+        #   # ${if path != null then path else null} = path;
+        # };
       }
     ];
 }

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -3,12 +3,12 @@
     {
       cfg,
       mkKeyOption,
-      pkgs,
       ...
     }:
     {
       config,
       lib,
+      pkgs,
       ...
     }:
     {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -104,7 +104,7 @@
       path = lib.mkOption {
         type = with lib.types; nullOr str;
         description = "The path of bookmarks";
-        default = "/home/zane/.config/yazi/bookmark";
+        default = "${cfg.home.homeDirectory}/.config/yazi/bookmark";
         # default = null;
       };
     };

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -127,8 +127,11 @@
       (setKeys cfg.hotkeys)
       {
         programs.yazi.yaziPlugins = {
-          require.yamb = yambConfig;
-          runtimeDeps = yambConfig.cli;
+          require.yamb = yambConfig // {
+            cli = lib.getExe yambConfig.cli; # get the executable path from the package
+          };
+          runtimeDeps = [ yambConfig.cli ]; # runtimeDeps expects a list here
+
         };
         # {
         #   inherit (yambConfig)

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -1,11 +1,11 @@
 {
   options =
     {
-      config,
+      cfg,
       mkKeyOption,
       ...
     }:
-    { lib, ... }:
+    { config, lib, ... }:
     {
       hotkeys = {
 

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -98,8 +98,12 @@
       };
       cli = lib.mkOption {
         type = with lib.types; either package str;
-        description = "The cli for fzf";
-        default = pkgs.fzf;
+        description = "The cli for fzf: either a package containing an executable or a string that gives the name of package in nixpkgs that contains an executable.";
+        example = [
+          "fzf"
+          pkgs.fzf
+        ];
+        default = "fzf";
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -105,7 +105,7 @@
         type = with lib.types; nullOr str;
         description = "The path of bookmarks";
         # default = "~/.config/yazi/bookmark";
-        # default = null;
+        default = null;
       };
     };
   config =

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -1,7 +1,7 @@
 {
   options =
     {
-      cfg,
+      config,
       mkKeyOption,
       ...
     }:
@@ -104,7 +104,7 @@
       path = lib.mkOption {
         type = with lib.types; nullOr str;
         description = "The path of bookmarks";
-        default = "${cfg.home.homeDirectory}/.config/yazi/bookmark";
+        default = "${config.home.homeDirectory}/.config/yazi/bookmark";
         # default = null;
       };
     };

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -84,28 +84,28 @@
             key = "d";
           }
         ];
-        default = [ ];
+        # default = [ ];
       };
       jump_notify = lib.mkOption {
         type = with lib.types; bool;
         description = "Recieve notification everytime you jump.";
-        default = true;
+        # default = true;
       };
       cli = lib.mkOption {
         type = with lib.types; str;
         description = "The cli for fzf";
-        default = "fzf";
+        # default = "fzf";
       };
       bookmarkKeys = lib.mkOption {
         type = with lib.types; separatedString "";
         description = "A string used for randomly generating keys, where the preceding characters have higher priority";
-        default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        # default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
       };
       path = lib.mkOption {
         type = with lib.types; nullOr str;
         description = "The path of bookmarks";
         # default = "~/.config/yazi/bookmark";
-        default = null;
+        # default = null;
       };
     };
   config =
@@ -115,10 +115,13 @@
       ...
     }:
     { lib, ... }:
+    let
+      nonNullCfg = lib.attrsets.filterAttrs (name: val: val == null) cfg;
+    in
     lib.mkMerge [
       (setKeys cfg.keys)
       {
-        programs.yazi.yaziPlugins.require.yamb = with cfg; {
+        programs.yazi.yaziPlugins.require.yamb = with nonNullCfg; {
           inherit
             bookmarks
             jump_notify
@@ -126,7 +129,7 @@
             path
             ;
           keys = bookmarkKeys;
-          ${if path != null then path else null} = path;
+          # ${if path != null then path else null} = path;
         };
       }
     ];

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -3,12 +3,12 @@
     {
       cfg,
       mkKeyOption,
+      pkgs,
       ...
     }:
     {
       config,
       lib,
-      pkgs,
       ...
     }:
     {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -75,7 +75,7 @@
         };
       };
       bookmarks = lib.mkOption {
-        type = with lib.types; listOf attrsOf string;
+        # type = with lib.types; listOf (attrsOf string);
         description = "Declarative bookmarks";
         example = [
           {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -3,7 +3,7 @@
     {
       cfg,
       mkKeyOption,
-      root,
+      pkgs,
       ...
     }:
     {
@@ -99,7 +99,7 @@
       cli = lib.mkOption {
         type = with lib.types; package;
         description = "The cli for fzf";
-        default = root.inputs.nixpkgs.fzf;
+        default = pkgs.fzf;
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -92,17 +92,17 @@
         default = true;
       };
       cli = lib.mkOption {
-        type = with lib.types; string;
+        type = with lib.types; str;
         description = "The cli for fzf";
         default = "fzf";
       };
       bookmarkKeys = lib.mkOption {
-        type = with lib.types; string;
+        type = with lib.types; separatedString "";
         description = "A string used for randomly generating keys, where the preceding characters have higher priority";
         default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
       };
       path = lib.mkOption {
-        type = with lib.types; string;
+        type = with lib.types; str;
         description = "The path of bookmarks";
         default = "$HOME/.config/yazi/bookmark";
       };

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -102,7 +102,7 @@
         default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
       };
       path = lib.mkOption {
-        type = with lib.types; str;
+        type = with lib.types; nullOr str;
         description = "The path of bookmarks";
         # default = "~/.config/yazi/bookmark";
         default = null;

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -104,7 +104,7 @@
       path = lib.mkOption {
         type = with lib.types; str;
         description = "The path of bookmarks";
-        default = "$HOME/.config/yazi/bookmark";
+        default = "~/.config/yazi/bookmark";
       };
     };
   config =

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -7,7 +7,7 @@
     }:
     { lib, ... }:
     {
-      keys = {
+      hotkeys = {
 
         save = mkKeyOption {
           on = [
@@ -96,7 +96,7 @@
         description = "The cli for fzf";
         # default = "fzf";
       };
-      bookmarkKeys = lib.mkOption {
+      keys = lib.mkOption {
         type = with lib.types; separatedString "";
         description = "A string used for randomly generating keys, where the preceding characters have higher priority";
         # default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -119,24 +119,18 @@
       nonNullCfg = lib.attrsets.filterAttrs (name: val: val == null) cfg;
     in
     lib.mkMerge [
-      (setKeys cfg.keys)
+      (setKeys cfg.hotkeys)
       {
-        programs.yazi.yaziPlugins.require.yamb =
-          with nonNullCfg;
-          let
-            keys = bookmarkKeys;
-          in
-          {
-            inherit
-              bookmarks
-              jump_notify
-              cli
-              path
-              keys
-              ;
-            # ${if bookmarkKeys == null then keys else null} = bookmarkKeys;
-            # ${if path != null then path else null} = path;
-          };
+        programs.yazi.yaziPlugins.require.yamb = with nonNullCfg; {
+          inherit
+            bookmarks
+            jump_notify
+            cli
+            path
+            keys
+            ;
+          # ${if path != null then path else null} = path;
+        };
       }
     ];
 }

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -116,7 +116,7 @@
     }:
     { lib, ... }:
     let
-      yambConfig = lib.attrsets.filterAttrs (name: val: val != null || name != "hotkeys") cfg;
+      yambConfig = lib.attrsets.filterAttrs (name: val: val != null && name != "hotkeys") cfg;
     in
     lib.mkMerge [
       (setKeys cfg.hotkeys)

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -97,7 +97,7 @@
         default = true;
       };
       cli = lib.mkOption {
-        type = with lib.types; package;
+        type = with lib.types; either package str;
         description = "The cli for fzf";
         default = pkgs.fzf;
       };
@@ -110,7 +110,6 @@
         type = with lib.types; nullOr str;
         description = "The path of bookmarks";
         default = "${config.home.homeDirectory}/.config/yazi/bookmark";
-        # default = null;
       };
     };
   config =
@@ -128,21 +127,12 @@
       {
         programs.yazi.yaziPlugins = {
           require.yamb = yambConfig // {
-            cli = lib.getExe yambConfig.cli; # get the executable path from the package
+            cli = lib.getExe (
+              if builtins.isString yambConfig.cli then pkgs."${yambConfig.cli}" else yambConfig.cli
+            ); # get the executable path from the package
           };
           runtimeDeps = [ yambConfig.cli ]; # runtimeDeps expects a list here
-
         };
-        # {
-        #   inherit (yambConfig)
-        #     bookmarks
-        #     jump_notify
-        #     cli
-        #     path
-        #     keys
-        #     ;
-        #   # ${if path != null then path else null} = path;
-        # };
       }
     ];
 }

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -123,9 +123,9 @@
             bookmarks
             jump_notify
             cli
-            path
             ;
           keys = bookmarkKeys;
+          ${if !lib.isNull path then path else null} = path;
         };
       }
     ];

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -1,0 +1,131 @@
+{
+  options =
+    {
+      cfg,
+      mkKeyOption,
+      ...
+    }:
+    { lib, ... }:
+    {
+      keys = {
+
+        save = mkKeyOption {
+          on = [
+            "u"
+            "a"
+          ];
+          run = "plugin yamb save";
+          desc = "Add bookmark";
+        };
+        jump = mkKeyOption {
+          on = [
+            "u"
+            "g"
+          ];
+          run = "plugin yamb jump_by_key";
+          desc = "Jump bookmark by key";
+        };
+        jumpByFzf = mkKeyOption {
+          on = [
+            "u"
+            "G"
+          ];
+          run = "plugin yamb jump_by_fzf";
+          desc = "Jump bookmark by fzf";
+        };
+        delete = mkKeyOption {
+          on = [
+            "u"
+            "d"
+          ];
+          run = "plugin yamb delete_by_key";
+          desc = "Delete bookmark by key";
+        };
+        deleteByFzf = mkKeyOption {
+          on = [
+            "u"
+            "D"
+          ];
+          run = "plugin yamb delete_by_fzf";
+          desc = "Delete bookmark by fzf";
+        };
+        deleteAll = mkKeyOption {
+          on = [
+            "u"
+            "A"
+          ];
+          run = "plugin yamb delete_all";
+          desc = "Delete all bookmarks";
+        };
+        rename = mkKeyOption {
+          on = [
+            "u"
+            "r"
+          ];
+          run = "plugin yamb rename_by_key";
+          desc = "Rename bookmark by key";
+        };
+        renameByFzf = mkKeyOption {
+          on = [
+            "u"
+            "R"
+          ];
+          run = "plugin yamb rename_by_fzf";
+          desc = "Rename bookmark by fzf";
+        };
+      };
+      bookmarks = lib.mkOption {
+        type = with lib.types; listOf attrsOf string;
+        description = "Declarative bookmarks";
+        example = [
+          {
+            tag = "Desktop";
+            path = "$HOME/Deskop";
+            key = "d";
+          }
+        ];
+        default = [ ];
+      };
+      jump_notify = lib.mkOption {
+        type = with lib.types; bool;
+        description = "Recieve notification everytime you jump.";
+        default = true;
+      };
+      cli = lib.mkOption {
+        type = with lib.types; string;
+        description = "The cli for fzf";
+        default = "fzf";
+      };
+      bookmarkKeys = lib.mkOption {
+        type = with lib.types; string;
+        description = "A string used for randomly generating keys, where the preceding characters have higher priority";
+        default = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+      };
+      path = lib.mkOption {
+        type = with lib.types; string;
+        description = "The path of bookmarks";
+        default = "$HOME/.config/yazi/bookmark";
+      };
+    };
+  config =
+    {
+      cfg,
+      setKeys,
+      ...
+    }:
+    { lib, ... }:
+    lib.mkMerge [
+      (setKeys cfg.keys)
+      {
+        programs.yazi.yaziPlugins.require.yamb = with cfg; {
+          inherit
+            bookmarks
+            jump_notify
+            cli
+            path
+            ;
+          keys = bookmarkKeys;
+        };
+      }
+    ];
+}

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -5,7 +5,12 @@
       mkKeyOption,
       ...
     }:
-    { config, lib, ... }:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
     {
       hotkeys = {
 
@@ -92,9 +97,9 @@
         default = true;
       };
       cli = lib.mkOption {
-        type = with lib.types; str;
+        type = with lib.types; package;
         description = "The cli for fzf";
-        default = "fzf";
+        default = pkgs.fzf;
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";
@@ -121,7 +126,10 @@
     lib.mkMerge [
       (setKeys cfg.hotkeys)
       {
-        programs.yazi.yaziPlugins.require.yamb = yambConfig;
+        programs.yazi.yaziPlugins = {
+          require.yamb = yambConfig;
+          runtimeDeps = yambConfig.cli;
+        };
         # {
         #   inherit (yambConfig)
         #     bookmarks

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -123,9 +123,10 @@
             bookmarks
             jump_notify
             cli
+            path
             ;
           keys = bookmarkKeys;
-          ${if !lib.isNull path then path else null} = path;
+          ${if path then path else null} = path;
         };
       }
     ];

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -8,6 +8,7 @@
     {
       config,
       lib,
+      pkgs,
       ...
     }:
     {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -3,7 +3,7 @@
     {
       cfg,
       mkKeyOption,
-      flake,
+      root,
       ...
     }:
     {
@@ -99,7 +99,7 @@
       cli = lib.mkOption {
         type = with lib.types; package;
         description = "The cli for fzf";
-        default = flake.inputs.nixpkgs.fzf;
+        default = root.inputs.nixpkgs.fzf;
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -8,7 +8,6 @@
     {
       config,
       lib,
-      pkgs,
       ...
     }:
     {
@@ -119,7 +118,7 @@
       setKeys,
       ...
     }:
-    { lib, ... }:
+    { lib, pkgs, ... }:
     let
       yambConfig = lib.attrsets.filterAttrs (name: val: val != null && name != "hotkeys") cfg;
     in

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -75,7 +75,7 @@
         };
       };
       bookmarks = lib.mkOption {
-        # type = with lib.types; listOf (attrsOf string);
+        type = with lib.types; listOf attrs;
         description = "Declarative bookmarks";
         example = [
           {

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -116,7 +116,7 @@
     }:
     { lib, ... }:
     let
-      yambConfig = lib.attrsets.filterAttrs (name: val: val == null || name == "hotkeys") cfg;
+      yambConfig = lib.attrsets.filterAttrs (name: val: val != null || name != "hotkeys") cfg;
     in
     lib.mkMerge [
       (setKeys cfg.hotkeys)

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -128,7 +128,7 @@
             cli
             path
             ;
-          keys = bookmarkKeys;
+          ${if bookmarkKeys == null then keys else null} = bookmarkKeys;
           # ${if path != null then path else null} = path;
         };
       }

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -3,7 +3,7 @@
     {
       cfg,
       mkKeyOption,
-      pkgs,
+      flake,
       ...
     }:
     {
@@ -99,7 +99,7 @@
       cli = lib.mkOption {
         type = with lib.types; package;
         description = "The cli for fzf";
-        default = pkgs.fzf;
+        default = flake.inputs.nixpkgs.fzf;
       };
       keys = lib.mkOption {
         type = with lib.types; separatedString "";

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -104,7 +104,8 @@
       path = lib.mkOption {
         type = with lib.types; str;
         description = "The path of bookmarks";
-        default = "~/.config/yazi/bookmark";
+        # default = "~/.config/yazi/bookmark";
+        default = null;
       };
     };
   config =

--- a/plugins/yamb/hm-module.nix
+++ b/plugins/yamb/hm-module.nix
@@ -126,7 +126,7 @@
             path
             ;
           keys = bookmarkKeys;
-          ${if path then path else null} = path;
+          ${if path != null then path else null} = path;
         };
       }
     ];

--- a/plugins/yamb/package.nix
+++ b/plugins/yamb/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
     owner = "h-hg";
     repo = "yamb.yazi";
     rev = "22af0033be18eead7b04c2768767d38ccfbaa05b";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    hash = "sha256-NMxZ8/7HQgs+BsZeH4nEglWsRH2ibAzq7hRSyrtFDTA=";
   };
 
   buildPhase = ''

--- a/plugins/yamb/package.nix
+++ b/plugins/yamb/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation {
+  pname = "yaziPlugins-yamb";
+  version = "unstable-2025-02-28";
+
+  src = fetchFromGitHub {
+    owner = "h-hg";
+    repo = "yamb.yazi";
+    rev = "22af0033be18eead7b04c2768767d38ccfbaa05b";
+    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  };
+
+  buildPhase = ''
+    mkdir $out
+    cp $src/* $out
+  '';
+
+  meta = with lib; {
+    description = "A Yazi plugin for bookmark management.";
+    homepage = "https://github.com/dedukun/bookmarks.yazi";
+    license = licenses.mit;
+    maintainers = [ ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Adds a module for [yamb.yazi](https://github.com/h-hg/yamb.yazi/tree/main).

The only weird thing about this module is that yamb takes the config option `keys`, so keybindings for the plugin are set through the nix option `keybinds` rather than `keys`, like other modules here do. If it's better to keep `keys` for keybindings and rename the plugin's `keys` option I can do that too.

Thanks for creating this project, I'm pretty new to nix and making HM modules, and this framework made it nice and easy!