### PR TITLE
[FEAT] add yatline support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,16 @@
                     };
                   })
                   (_: {
+                    config = lib.mkIf (cfg.enable && cfg ? "preRequire") {
+                      programs.yazi.yaziPlugins.preRequire = cfg.preRequire;
+                    };
+                  })
+                  (_: {
+                    config = lib.mkIf (cfg.enable && cfg ? "postRequire") {
+                      programs.yazi.yaziPlugins.postRequire = cfg.postRequire;
+                    };
+                  })
+                  (_: {
                     config = lib.mkIf (cfg.enable && cfg ? "extraConfig" && cfg.extraConfig != "") {
                       programs.yazi.yaziPlugins.extraConfig = cfg.extraConfig;
                     };

--- a/plugins/yatline/hm-module.nix
+++ b/plugins/yatline/hm-module.nix
@@ -3,6 +3,32 @@
     _:
     { lib, ... }:
     {
+      theme = {
+        name = lib.mkOption {
+          type =
+            with lib.types;
+            nullOr (enum [
+              "catppuccin"
+            ]);
+          description = ''
+            The name of the theme to set.
+            Note that this is limited to the yatline theme plugins currently packaged.
+          '';
+          example = "catppuccin";
+          default = null;
+        };
+
+        setup = lib.mkOption {
+          type = with lib.types; either str attrs;
+          description = ''
+            Options to pass to theme plugin when running `setup` on it.
+            Note that this is highly specific to the theme in question.
+          '';
+          example = "mocha";
+          default = { };
+        };
+      };
+
       # NOTE: yatline has a lot of configuration options
       extraSetup = lib.mkOption {
         type = with lib.types; attrs;
@@ -27,8 +53,31 @@
     };
   config =
     { cfg, ... }:
-    { pkgs, ... }:
+    { lib, pkgs, ... }:
+    let
+      luaFormat = lib.generators.toLua { };
+      requirePlugin = name: setup: ''
+        require("${name}"):setup(${if setup != { } then luaFormat setup else ""})
+      '';
+      themeIsSet = !isNull cfg.theme.name;
+      themeName = "yatline-${cfg.theme.name}";
+    in
     {
-      programs.yazi.yaziPlugins.require."yatline" = cfg.extraSetup;
+      programs.yazi = {
+        plugins = lib.mkIf themeIsSet {
+          ${themeName} = pkgs.yaziPlugins.${themeName};
+        };
+
+        yaziPlugins = {
+          preRequire."yatline" = lib.mkIf themeIsSet ''
+            local yatline_theme = ${requirePlugin themeName cfg.theme.setup}
+          '';
+          require."yatline" =
+            cfg.extraSetup
+            // (lib.optionalAttrs themeIsSet {
+              theme = if themeIsSet then (lib.generators.mkLuaInline "yatline_theme") else null;
+            });
+        };
+      };
     };
 }

--- a/plugins/yatline/hm-module.nix
+++ b/plugins/yatline/hm-module.nix
@@ -1,0 +1,34 @@
+{
+  options =
+    _:
+    { lib, ... }:
+    {
+      # NOTE: yatline has a lot of configuration options
+      extraSetup = lib.mkOption {
+        type = with lib.types; attrs;
+        description = "Extra configuration to pass to `setup`";
+        example = {
+          show_background = false;
+          header_line = {
+            left = {
+              section_a = [
+                {
+                  type = "line";
+                  custom = false;
+                  name = "tabs";
+                  params = [ "left" ];
+                }
+              ];
+            };
+          };
+        };
+        default = { };
+      };
+    };
+  config =
+    { cfg, ... }:
+    { pkgs, ... }:
+    {
+      programs.yazi.yaziPlugins.require."yatline" = cfg.extraSetup;
+    };
+}


### PR DESCRIPTION
# Description
I added support for [yatline](https://github.com/imsi32/yatline.yazi), as well one theme for it, [yatline-catppuccin](https://github.com/imsi32/yatline-catppuccin.yazi), and one addon, [yatline-githead](https://github.com/imsi32/yatline-githead.yazi), both of which are treated as part of yatline's module.

I accomplished this by adding a `preRequire` option and a `postRequire` option to the module, which should hopefully also be general enough to be used to configure any future plugins that require similar special handling. No other plugins have had these options defined and they should not affect backwards compatibility.

For yatline and yatline-githead, I gave them an `extraSetup` and `setup` option respectively that take an attrset. I opted for this rather than individually defining every option individually because they both have a lot of options to the point that I figured that they would be difficult to maintain, especially if more addons are added in the future.

# Issues
- Closes #47

# Todos (please checkmark)
- [x] I formatted the code using nix fmt
- [x] I updated all the modules (if applicable, see issue)
- [x] I updated the documentation (if applicable)
- [x] I rebuilt all plugins
- [x] I tested the change locally
- [x] I ran the tests (TBD)
