### PR TITLE
[BUG FIX] 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system' (#52)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -207,7 +207,7 @@
                 { lib, ... }:
                 {
                   imports =
-                    ((instantiate_lib lib (inputs.nixpkgs.legacyPackages.${system})).homeManagerModulesImports)
+                    ((instantiate_lib lib (inputs.nixpkgs.legacyPackages.${pkgs.stdenv.hostPlatform.system})).homeManagerModulesImports)
                     ++ [ ./module.nix ];
                 };
               default = yaziPlugins;


### PR DESCRIPTION
Closes #52 
