### PR TITLE
fix: replace deprecated lib.fold with lib.foldr

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -100,5 +100,5 @@ in
           showOption (baseOptionPath' ++ oldName)
         }' has been renamed to '${showOption (baseOptionPath' ++ newName)}'" null;
     });
-  recursiveUpdateList = lib.fold lib.recursiveUpdate { };
+  recursiveUpdateList = lib.foldr lib.recursiveUpdate { };
 }


### PR DESCRIPTION
## Summary
- replace `lib.fold` with `lib.foldr` in `lib.nix`
- keep behavior unchanged while removing the deprecation warning on newer nixpkgs

## References
- nixpkgs deprecates `fold` as an alias of `foldr` in `lib/lists.nix`: https://github.com/NixOS/nixpkgs/blob/master/lib/lists.nix
- the deprecation warning itself comes from the `fold = warn \"fold has been deprecated, use foldr instead\" foldr;` definition in that file