### PR TITLE
[FEAT] smart-enter: add open_multi option

### DIFF
--- a/plugins/smart-enter/hm-module.nix
+++ b/plugins/smart-enter/hm-module.nix
@@ -1,7 +1,8 @@
 {
   options =
     { mkKeyOption, ... }:
-    _: {
+    { lib, ... }:
+    {
       keys = {
         toggle = mkKeyOption {
           on = [ "l" ];
@@ -9,6 +10,19 @@
           desc = "Enter the child directory, or open the file";
         };
       };
+
+      open_multi = lib.mkEnableOption "Allow opening multiple files";
     };
-  config = { cfg, setKeys, ... }: _: (setKeys cfg.keys);
+
+  config =
+    { cfg, setKeys, ... }:
+    { lib, ... }:
+    lib.mkMerge [
+      (setKeys cfg.keys)
+      {
+        programs.yazi.yaziPlugins.require."smart-enter" = {
+          inherit (cfg) open_multi;
+        };
+      }
+    ];
 }


### PR DESCRIPTION
# Description
 Added the upstream "open_multi" config option.
 
 # Issues
- Closes #66

# Todos
- [x] I formatted the code using nix fmt
- [x] I updated all the modules (if applicable, see issue)
- [ ] I updated the documentation (if applicable)
- [x] I rebuilt all plugins
- [x] I tested the change locally
- [ ] I ran the tests (TBD)